### PR TITLE
[CAPAC-2076] Update vault agent requested resources

### DIFF
--- a/security/configure-with-vault/README.md
+++ b/security/configure-with-vault/README.md
@@ -289,6 +289,8 @@ podTemplate:
     ...
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt

--- a/security/configure-with-vault/confluent-platform-norbac-vault.yaml
+++ b/security/configure-with-vault/confluent-platform-norbac-vault.yaml
@@ -19,6 +19,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -63,6 +65,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -170,6 +174,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -255,6 +261,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -339,6 +347,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -409,6 +419,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -512,6 +524,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -562,6 +576,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt

--- a/security/configure-with-vault/rbac/confluent-platform-withrbac-vault.yaml
+++ b/security/configure-with-vault/rbac/confluent-platform-withrbac-vault.yaml
@@ -19,6 +19,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -91,6 +93,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -225,6 +229,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -312,6 +318,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -398,6 +406,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -481,6 +491,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt

--- a/security/configure-with-vault/rbac/cp_component.yaml
+++ b/security/configure-with-vault/rbac/cp_component.yaml
@@ -19,6 +19,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -108,6 +110,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -196,6 +200,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -281,6 +287,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt

--- a/security/configure-with-vault/rbac/zk_kafka.yaml
+++ b/security/configure-with-vault/rbac/zk_kafka.yaml
@@ -19,6 +19,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt
@@ -91,6 +93,8 @@ spec:
     serviceAccountName: confluent-sa
     annotations:
       vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-requests-cpu: 20m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
       vault.hashicorp.com/agent-inject-status: update
       vault.hashicorp.com/preserve-secret-case: "true"
       vault.hashicorp.com/agent-inject-secret-jksPassword.txt: secret/jksPassword.txt


### PR DESCRIPTION
# Background
The vault agent (for vault v3) is massively overprovisioned by default. See this thread for more details: https://confluent.slack.com/archives/C011BE2U8DC/p1702503223374339

This pr adds annotations to reduce the resource requests of the vault agent. 

# Actions
- Please make sure the indentation is correct. This PR was generated by a script, but unfortunately each service's yaml files have different indentations. Double check that it is correct!
- If you have any concerns with the values used here, feel free to take a look at this runbook to update to better values: https://ccloud-production.datadoghq.com/notebook/7119272/vault-agent-cpu-mem-analysis?range=2592000000&start=1699911619030&live=true
- However for 99% of services, these cpu/mem values should be more than plenty (even with a 50% buffer).
